### PR TITLE
Ignore Ruby-specific build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,37 @@
 **/.DS_Store
+
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalisation:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc


### PR DESCRIPTION
From https://github.com/github/gitignore/blob/master/Ruby.gitignore

Ignoring some build files (.gem and etc.) our future Ruby builds